### PR TITLE
T9: Fetch Categories

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import { AxiosInstance } from "./axios/axiosInstance";
 
 import { useDispatch } from "react-redux";
 import { autoLoginAction } from "./store/actions/userAction";
+import { fetchCategories } from "./store/actions/globalActions";
 
 function App() {
   const dispatch = useDispatch();
@@ -23,6 +24,7 @@ function App() {
   useEffect(() => {
     //userAction içerisin de bulunan autologin fonksiyonu.
     dispatch(autoLoginAction());
+    dispatch(fetchCategories());
   }, []);
 
   return (

--- a/src/Components/CategoryCard.jsx
+++ b/src/Components/CategoryCard.jsx
@@ -1,18 +1,30 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-export const CategoryCard = ({ data }) => {
+export const CategoryCard = ({ data, gender, itemCategory }) => {
+  //Url için gender propunu lowercase'e dönüştürme.
+  const genderUrl = gender.toLowerCase();
+  //Apiden Gelen -> "code": "k:elbise" verisini splitleyip "elbise" kısmını kullanma.
+  const urlSplit = itemCategory.split(":");
+  const categoryUrl = urlSplit[1];
   return (
-    <div className="max-w-[200px] md:w-[333px] md:mx-auto">
-      {/* Linkler nereye gidecek? */}
-      <Link>
+    <div className="md:mx-auto md:w-full ">
+      {/* Kategori linki nasıl olmalı? , nereye gidecekler? */}
+      <Link
+        to={`/shopping/:${genderUrl}/:${categoryUrl}`}
+        className="flex flex-wrap"
+      >
         <div
-          style={{ backgroundImage: `url(${data.imageUrl})` }}
-          className="max-w-[200px] h-[220px]"
+          style={{
+            backgroundImage: `url(${data.img})`,
+            backgroundSize: "cover",
+          }}
+          className="w-[250px] h-[220px] md:w-[370px] md:mx-auto "
         >
-          <div className="flex flex-col items-center justify-center h-full font-bold text-white text-base tracking-[0.2px] gap-4">
-            <span>{data.categoryName}</span>
-            <span>{data.itemCount}</span>
+          <div className="flex flex-col items-center justify-center h-full font-bold text-white text-base tracking-[0.2px] gap-4 md:flex-wrap">
+            <span>{data.title}</span>
+            <span>Rating: {data.rating}</span>
+            <p>{gender}</p>
           </div>
         </div>
       </Link>

--- a/src/Components/ShopDropDown.jsx
+++ b/src/Components/ShopDropDown.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+export const ShopDropDown = () => {
+  const categoryData = useSelector((store) => store.global.categories);
+  //Genderdan bize -> k ya da e dönüyor.
+
+  return (
+    <div className="mx-auto flex  items-center justify-center ">
+      <div className="group relative cursor-pointer ">
+        <div className="flex items-center justify-between  bg-white ">
+          <a className="menu-hover " onClick="">
+            Shop
+          </a>
+          <span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              className="h-4 w-4"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+              />
+            </svg>
+          </span>
+        </div>
+        <div className="invisible absolute z-50 flex w-[150px] flex-col bg-gray-100 py-1 px-2 text-gray-800 shadow-xl group-hover:visible">
+          {categoryData.map((item, index) => (
+            <Link
+              className="my-2 block border-b border-gray-100 py-1 font-semibold text-gray-500 hover:text-black md:mx-2"
+              key={index}
+              to={`/shopping/:${
+                item.gender === "k" ? "kadın" : "erkek"
+              }/:${item.title.toLowerCase()}`}
+            >
+              {item.gender === "k" ? "Kadın" : "Erkek"} {item.title}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/Layout/CategoryCardList.jsx
+++ b/src/Layout/CategoryCardList.jsx
@@ -1,15 +1,33 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { CategoryCard } from "../Components/CategoryCard";
-import { useData } from "../context/DataContext";
+
+import { useDispatch, useSelector } from "react-redux";
+
 export const CategoryCardList = () => {
-  const { categoryData } = useData();
+  const categoryData = useSelector((store) => store.global.categories);
+  //Apiden gelen veriyi sortlama Rating - (Büyükten > Küçüğe)
+  const sortedData = [...categoryData].sort((a, b) => b.rating - a.rating);
+  console.log(sortedData);
+  //Ratinge göre dizilmiş yeni verinin ilk 5 verisini alma.
+  const categoryTopFive = sortedData.slice(0, 5);
+  useEffect(() => {}, []);
+
   return (
-    <div className="max-w-[1050px] flex flex-row gap-3 mx-auto md:flex-wrap md:flex-col ">
-      {categoryData.map((item, index) => (
-        <div key={index} className="w-full ">
-          <CategoryCard data={item} />
-        </div>
-      ))}
+    <div className="max-w-[1440px] flex flex-row mx-auto md:flex-wrap md:flex-col justify-between  md:gap-4 ">
+      <div className="w-full flex flex-row mx-6 md:flex-wrap md:flex-col justify-between  gap-4 flex-wrap md:items-center md:mx-0">
+        {categoryTopFive.map((item, index) => (
+          <div
+            key={index}
+            className="flex flex-row flex-wrap  md:flex-col  sm:mx-0 "
+          >
+            <CategoryCard
+              data={item}
+              gender={item.gender === "e" ? "Erkek" : "Kadın"}
+              itemCategory={item.code}
+            />
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/Layout/Header.jsx
+++ b/src/Layout/Header.jsx
@@ -16,6 +16,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { logOutActionCreator } from "../store/actions/userAction";
 import { GravatarPP } from "../Components/GravatarPP";
+import { ShopDropDown } from "../Components/ShopDropDown";
 
 export const Header = () => {
   const userLoggedIn = useSelector((store) => store.user);
@@ -71,9 +72,11 @@ export const Header = () => {
               <h3 className="text-2xl font-bold">Bandage</h3>
             </Link>
           </div>
-          <div className="flex gap-[1rem] font-bold text-[#737373] text-sm ml-20 md:ml-0 md:flex-col md:w-full md:items-center md:text-xl md:order-last md:mb-12">
+          <div className="flex gap-[1rem] font-bold text-[#737373] text-sm ml-20 md:ml-0 md:flex-col md:w-full md:items-center md:text-xl md:order-last md:mb-12 items-center">
             <Link to={"/"}>Home</Link>
-            <Link to={"/shop"}>Shop</Link>
+            <Link to={"/shop"}>
+              <ShopDropDown />
+            </Link>
             <Link to={"/about"}>About</Link>
             <Link to={"/contact"}>Contact</Link>
             <Link to={"/product"}>Pages</Link>

--- a/src/Layout/ProductListPage/ProductListPage.jsx
+++ b/src/Layout/ProductListPage/ProductListPage.jsx
@@ -14,11 +14,11 @@ const ProductListPage = () => {
       <div>
         {/* Sayfanin en üstü */}
         <div className="w-full bg-pbGray md:py-8">
-          <div className="max-w-[1050px] mx-auto flex justify-between py-4 md:flex-wrap md:flex-col md:gap-8">
-            <div className="flex justify-center">
+          <div className="max-w-[1440px] mx-auto flex justify-between py-4 md:flex-wrap md:flex-col md:gap-8">
+            <div className="flex justify-center ml-6 md:ml-0">
               <h3 className="font-bold text-sBlack text-2xl">Shop</h3>
             </div>
-            <div className="flex justify-center gap-2 items-center">
+            <div className="flex justify-center gap-2 items-center mr-6 md:mr-0">
               <Link to={"/"} className="font-bold">
                 Home
               </Link>

--- a/src/store/actions/globalActions.js
+++ b/src/store/actions/globalActions.js
@@ -27,3 +27,12 @@ export const fetchRoles = () => (dispatch) => {
     })
     .catch((err) => console.log(err));
 };
+
+export const fetchCategories = () => (dispatch) => {
+  AxiosInstance.get("/categories")
+    .then((res) => {
+      dispatch(setCategories(res.data));
+      console.log(res.data);
+    })
+    .catch((err) => console.log(err));
+};


### PR DESCRIPTION
Fixes #15
 Fetch categories by thunk action and store it in the gobal reducer -> (Done)
 endpoint “/categories“ -> (Done)
 list categories on the screen -> (Done)
 categories should be link -> (Done)
 **on click it should navigate to “/shopping/:gender/:category” -> (Done but have questions about this)**
 top 5 categories should be listed on the screen with images regarding “rating” value -> (Done)
 all categories should be listed in drop down menu on header -> (Done)